### PR TITLE
Query PR number in SonarQube API call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true,
+    "cSpell.words": [
+        "sonarqube"
+    ]
+}

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
   github_api_base_url:
     description: "Base URL for GitHub API"
     required: true
+  verbose:
+    description: "Verbose output"
+    required: false
+    default: "false"
 outputs:
   quality_check:
     description: "Quality check status from SonarQube"
@@ -39,3 +43,4 @@ runs:
     REPO_NAME: ${{ inputs.repo_name }}
     PR_NUMBER: ${{ inputs.pr_number }}
     GITHUB_API_BASE_URL: ${{ inputs.github_api_base_url }}
+    VERBOSE: ${{ inputs.verbose }}

--- a/main.py
+++ b/main.py
@@ -2,108 +2,131 @@ import os
 import requests
 from github import Github
 
-# Configuration of environment variables
-SONAR_HOST_URL = os.getenv('SONAR_HOST_URL')
-SONAR_PROJECTKEY = os.getenv('SONAR_PROJECTKEY')
-SONAR_TOKEN = os.getenv('SONAR_TOKEN')
+class SonarQubePrComment:
+    def __init__(self, sonar_host_url, sonar_projectkey, sonar_token, github_token, repo_name, pr_number, github_api_base_url, verbose):
+        self.sonar_host_url = sonar_host_url
+        self.sonar_projectkey = sonar_projectkey
+        self.sonar_token = sonar_token
+        self.github_token = github_token
+        self.repo_name = repo_name
+        self.pr_number = pr_number
+        self.github_api_base_url = github_api_base_url
+        self.verbose = verbose
 
-GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')  # GitHub token
-REPO_NAME = os.getenv('GITHUB_REPOSITORY')  # Ex: "user/repository"
-PR_NUMBER = os.getenv('PR_NUMBER')  # Pull Request number
-GITHUB_API_BASE_URL = os.getenv('GITHUB_API_BASE_URL') or None
-VERBOSE = os.getenv('VERBOSE') == 'true'
+        if verbose:
+            self.verbose_print(f"Configuration:")
+            self.verbose_print(f"SONAR_HOST_URL: {self.sonar_host_url}")
+            self.verbose_print(f"SONAR_PROJECTKEY: {self.sonar_projectkey}")
+            self.verbose_print(f"SONAR_TOKEN: {'[REDACTED]' if self.sonar_token else 'None'}")
+            self.verbose_print(f"GITHUB_TOKEN: {'[REDACTED]' if self.github_token else 'None'}")
+            self.verbose_print(f"GITHUB_REPOSITORY: {self.repo_name}")
+            self.verbose_print(f"PR_NUMBER: {self.pr_number}")
+            self.verbose_print(f"GITHUB_API_BASE_URL: {self.github_api_base_url}")
+            self.verbose_print(f"VERBOSE: {self.verbose}")
 
-def verbose_print(message):
-    if VERBOSE:
-        print(f"VERBOSE: {message}")
+    def verbose_print(self, message):
+        if self.verbose:
+            print(f"VERBOSE: {message}")
 
-def get_quality_gate_status():
-    quality_gate_url = f"{SONAR_HOST_URL}/api/qualitygates/project_status?projectKey={SONAR_PROJECTKEY}"
+    def get_quality_gate_status(self):
+        quality_gate_url = f"{self.sonar_host_url}/api/qualitygates/project_status?projectKey={self.sonar_projectkey}"
 
-    # Debug output for configuration
-    verbose_print(f"Configuration:")
-    verbose_print(f"SONAR_HOST_URL: {SONAR_HOST_URL}")
-    verbose_print(f"SONAR_PROJECTKEY: {SONAR_PROJECTKEY}")
-    verbose_print(f"SONAR_TOKEN: {'[REDACTED]' if SONAR_TOKEN else 'None'}")
-    verbose_print(f"Quality Gate URL: {quality_gate_url}")
+        # Debug output for configuration
+        self.verbose_print(f"Configuration:")
+        self.verbose_print(f"SONAR_HOST_URL: {self.sonar_host_url}")
+        self.verbose_print(f"SONAR_PROJECTKEY: {self.sonar_projectkey}")
+        self.verbose_print(f"SONAR_TOKEN: {'[REDACTED]' if self.sonar_token else 'None'}")
+        self.verbose_print(f"Quality Gate URL: {quality_gate_url}")
 
-    # Make the request to the SonarQube API
-    try:
-        response = requests.get(quality_gate_url, auth=(SONAR_TOKEN, ''))
-        verbose_print(f"Response Status Code: {response.status_code}")
-        verbose_print(f"Response Headers: {response.headers}")
+        # Make the request to the SonarQube API
+        try:
+            response = requests.get(quality_gate_url, auth=(self.sonar_token, ''))
+            self.verbose_print(f"Response Status Code: {response.status_code}")
+            self.verbose_print(f"Response Headers: {response.headers}")
 
-        if response.status_code != 200:
-            verbose_print(f"Error Response Body: {response.text}")
+            if response.status_code != 200:
+                self.verbose_print(f"Error Response Body: {response.text}")
 
-        response.raise_for_status()
+            response.raise_for_status()
 
-        project_status = response.json()
-        verbose_print(f"Full Response JSON: {project_status}")
+            project_status = response.json()
+            self.verbose_print(f"Full Response JSON: {project_status}")
 
-        quality_gate_status = project_status['projectStatus']['status']
-        print(f"Quality gate status retrieved: {quality_gate_status}")
+            quality_gate_status = project_status['projectStatus']['status']
+            self.verbose_print(f"Quality gate status retrieved: {quality_gate_status}")
 
-        return quality_gate_status, project_status
-    except requests.exceptions.RequestException as e:
-        verbose_print(f"Request Exception: {str(e)}")
-        raise
-    except KeyError as e:
-        verbose_print(f"JSON Structure Error: {str(e)}")
-        verbose_print(f"Available Keys: {project_status.keys() if 'project_status' in locals() else 'No response data'}")
-        raise
+            return quality_gate_status, project_status
+        except requests.exceptions.RequestException as e:
+            self.verbose_print(f"Request Exception: {str(e)}")
+            raise
+        except KeyError as e:
+            self.verbose_print(f"JSON Structure Error: {str(e)}")
+            self.verbose_print(f"Available Keys: {project_status.keys() if 'project_status' in locals() else 'No response data'}")
+            raise
 
-def extract_code_details(project_status, status_filter):
-    # Filter conditions based on status ("OK" or "ERROR")
-    conditions = project_status['projectStatus']['conditions']
-    filtered_conditions = [condition for condition in conditions if condition['status'] == status_filter]
+    def extract_code_details(self, project_status, status_filter):
+        # Filter conditions based on status ("OK" or "ERROR")
+        conditions = project_status['projectStatus']['conditions']
+        filtered_conditions = [condition for condition in conditions if condition['status'] == status_filter]
 
-    # Create formatted strings with details of the filtered conditions
-    details = [
-        f"\n{'✅' if status_filter == 'OK' else '💣'}Status: {condition['status']}, \n"
-        f"MetricKey: {condition['metricKey']}\n"
-        f"Comparator: {condition['comparator']}\n"
-        f"ErrorThreshold: {condition['errorThreshold']}\n"
-        f"ActualValue: {condition['actualValue']}\n"
-        for condition in filtered_conditions
-    ]
-    
-    return ''.join(details)
-
-def code_validation():
-    quality_gate_status, project_status = get_quality_gate_status()
-
-    if quality_gate_status == "OK":
-        code_ok = extract_code_details(project_status, "OK")
-        result = f"👋 Hey, the Quality Gate has PASSED.{code_ok}"
-    elif quality_gate_status == "ERROR":
-        code_fail = extract_code_details(project_status, "ERROR")
-        result = f"👋 Hey, the Quality Gate has FAILED.{code_fail}"
-    else:
-        result = "quality_check=ERROR CONFIGURATION"
-
-    return result
-
-def comment_on_pull_request(body, base_url=None):
-    # Authenticate with GitHub
-    if base_url is not None:
-        g = Github(GITHUB_TOKEN, base_url=base_url)
-    else:
-        g = Github(GITHUB_TOKEN)
+        # Create formatted strings with details of the filtered conditions
+        details = [
+            f"\n{'✅' if status_filter == 'OK' else '💣'}Status: {condition['status']}, \n"
+            f"MetricKey: {condition['metricKey']}\n"
+            f"Comparator: {condition['comparator']}\n"
+            f"ErrorThreshold: {condition['errorThreshold']}\n"
+            f"ActualValue: {condition['actualValue']}\n"
+            for condition in filtered_conditions
+        ]
         
-    repo = g.get_repo(REPO_NAME)
-    pull_request = repo.get_pull(int(PR_NUMBER))
+        return ''.join(details)
 
-    print(f"Commenting on Pull Request #{PR_NUMBER}.")
-    # Comment on the Pull Request
-    pull_request.create_issue_comment(body)
+    def code_validation(self):
+        quality_gate_status, project_status = self.get_quality_gate_status()
+
+        if quality_gate_status == "OK":
+            code_ok = self.extract_code_details(project_status, "OK")
+            result = f"👋 Hey, the Quality Gate has PASSED.{code_ok}"
+        elif quality_gate_status == "ERROR":
+            code_fail = self.extract_code_details(project_status, "ERROR")
+            result = f"👋 Hey, the Quality Gate has FAILED.{code_fail}"
+        else:
+            result = "quality_check=ERROR CONFIGURATION"
+
+        return result
+
+    def comment_on_pull_request(self, body):
+        if not (self.github_token and self.repo_name and self.pr_number):
+            self.verbose_print("Error: GitHub token, repository, or PR number not configured.")
+
+        # Authenticate with GitHub
+        if self.github_api_base_url is not None:
+            g = Github(self.github_token, base_url=self.github_api_base_url)
+        else:
+            g = Github(self.github_token)
+            
+        repo = g.get_repo(self.repo_name)
+        pull_request = repo.get_pull(int(self.pr_number))
+
+        self.verbose_print(f"Commenting on Pull Request #{self.pr_number}.")
+        # Comment on the Pull Request
+        pull_request.create_issue_comment(body)
 
 if __name__ == "__main__":
+
+    sonarqube_pr_comment = SonarQubePrComment(
+        sonar_host_url = os.getenv('SONAR_HOST_URL'),
+        sonar_projectkey = os.getenv('SONAR_PROJECTKEY'),
+        sonar_token = os.getenv('SONAR_TOKEN'),
+        github_token = os.getenv('GITHUB_TOKEN'),
+        repo_name = os.getenv('GITHUB_REPOSITORY'),
+        pr_number = os.getenv('PR_NUMBER'),
+        github_api_base_url = os.getenv('GITHUB_API_BASE_URL') or None,
+        verbose = os.getenv('VERBOSE') == 'true'
+    )
+
     # Execute code validation
-    result = code_validation()
+    result = sonarqube_pr_comment.code_validation()
     
     # Comment on the Pull Request
-    if GITHUB_TOKEN and REPO_NAME and PR_NUMBER:
-        comment_on_pull_request(result, base_url=GITHUB_API_BASE_URL)
-    else:
-        print("Error: GitHub token, repository, or PR number not configured.")
+    sonarqube_pr_comment.comment_on_pull_request(result)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 import requests
 from github import Github
+from requests.exceptions import RequestException
 
 class SonarQubePrComment:
     def __init__(self, sonar_host_url, sonar_projectkey, sonar_token, github_token, repo_name, pr_number, github_api_base_url, verbose):
@@ -56,7 +57,7 @@ class SonarQubePrComment:
             self.verbose_print(f"Quality gate status retrieved: {quality_gate_status}")
 
             return quality_gate_status, project_status
-        except requests.exceptions.RequestException as e:
+        except RequestException as e:
             self.verbose_print(f"Request Exception: {str(e)}")
             raise
         except KeyError as e:
@@ -96,7 +97,9 @@ class SonarQubePrComment:
         except Exception as e:
             match e:
                 case KeyError():
-                    return "quality_check=API ERROR: PARSE ERROR"
+                    return f"quality_check=API ERROR: PARSE ERROR: {str(e)}"
+                case RequestException():
+                    return f"quality_check=API ERROR: REQUEST ERROR: {str(e)}"
                 case _:
                     return f"quality_check=API ERROR: {str(e)}"
 

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ class SonarQubePrComment:
             print(f"VERBOSE: {message}")
 
     def get_quality_gate_status(self):
-        quality_gate_url = f"{self.sonar_host_url}/api/qualitygates/project_status?projectKey={self.sonar_projectkey}"
+        quality_gate_url = f"{self.sonar_host_url}/api/qualitygates/project_status?projectKey={self.sonar_projectkey}&pullRequest={self.pr_number}"
 
         # Debug output for configuration
         self.verbose_print(f"Configuration:")

--- a/main.py
+++ b/main.py
@@ -11,6 +11,11 @@ GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')  # GitHub token
 REPO_NAME = os.getenv('GITHUB_REPOSITORY')  # Ex: "user/repository"
 PR_NUMBER = os.getenv('PR_NUMBER')  # Pull Request number
 GITHUB_API_BASE_URL = os.getenv('GITHUB_API_BASE_URL') or None
+VERBOSE = os.getenv('VERBOSE') == 'true'
+
+def verbose_print(message):
+    if VERBOSE:
+        print(f"VERBOSE: {message}")
 
 def get_quality_gate_status():
     quality_gate_url = f"{SONAR_HOST_URL}/api/qualitygates/project_status?projectKey={SONAR_PROJECTKEY}"

--- a/main.py
+++ b/main.py
@@ -25,12 +25,21 @@ class SonarQubePrComment:
             self.verbose_print(f"GITHUB_API_BASE_URL: {self.github_api_base_url}")
             self.verbose_print(f"VERBOSE: {self.verbose}")
 
+        if not self.pr_number.isdigit():
+            self.pr_number = None
+        if self.github_token == '':
+            self.github_token = None
+        if self.github_api_base_url == '':
+            self.github_api_base_url = None
+
     def verbose_print(self, message):
         if self.verbose:
             print(f"VERBOSE: {message}")
 
     def get_quality_gate_status(self):
-        quality_gate_url = f"{self.sonar_host_url}/api/qualitygates/project_status?projectKey={self.sonar_projectkey}&pullRequest={self.pr_number}"
+        quality_gate_url = f"{self.sonar_host_url}/api/qualitygates/project_status?projectKey={self.sonar_projectkey}"
+        if self.pr_number is not None:
+            quality_gate_url = f"{quality_gate_url}&pullRequest={self.pr_number}"
 
         # Debug output for configuration
         self.verbose_print(f"Configuration:")
@@ -104,8 +113,9 @@ class SonarQubePrComment:
                     return f"quality_check=API ERROR: {str(e)}"
 
     def comment_on_pull_request(self, body):
-        if not (self.github_token and self.repo_name and self.pr_number):
-            self.verbose_print("Error: GitHub token, repository, or PR number not configured.")
+        if self.pr_number is None or self.github_token is None or self.repo_name is None:
+            self.verbose_print("Error: GitHub token, repository, or PR number not configured. Exiting.")
+            return
 
         # Authenticate with GitHub
         if self.github_api_base_url is not None:

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ class SonarQubePrComment:
             self.verbose_print(f"GITHUB_API_BASE_URL: {self.github_api_base_url}")
             self.verbose_print(f"VERBOSE: {self.verbose}")
 
-        if not self.pr_number.isdigit():
+        if self.pr_number is not None and not self.pr_number.isdigit():
             self.pr_number = None
         if self.github_token == '':
             self.github_token = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+PyGithub>=2.1.1 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.31.0
-PyGithub>=2.1.1 
+PyGithub>=2.1.1
+responses>=0.24.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.31.0
 PyGithub>=2.1.1
 responses>=0.24.1
+parameterized>=0.9.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the tests directory a Python package 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,162 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from requests.exceptions import RequestException
+
+from main import SonarQubePrComment
+
+class TestSonarQubeIntegration(unittest.TestCase):
+
+    def setUp(self):
+        self.test_object = SonarQubePrComment(
+            'https://sonar.example.com',
+            'my_project',
+            'my_token',
+            'my_github_token',
+            'my_repo',
+            '123',
+            'https://api.github.com',
+            'true'
+        )
+
+    def get_mock_response_ok(self):
+        # Mock response for a passing quality gate
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'projectStatus': {
+                'status': 'OK',
+                'conditions': [
+                    {
+                        'status': 'OK',
+                        'metricKey': 'coverage',
+                        'comparator': 'GT',
+                        'errorThreshold': '80',
+                        'actualValue': '85'
+                    }
+                ]
+            }
+        }
+        return mock_response
+    
+    def get_mock_response_quality_gate_error(self):
+        # Mock response for a failing quality gate
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'projectStatus': {
+                'status': 'ERROR',
+                'conditions': [
+                    {
+                        'status': 'ERROR',
+                        'metricKey': 'coverage',
+                        'comparator': 'GT',
+                        'errorThreshold': '80',
+                        'actualValue': '75'
+                    }
+                ]
+            }
+        }
+        return mock_response
+    
+    def get_mock_response_api_http_error(self):
+        # Mock response for an API error
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = 'Unauthorized'
+        return mock_response
+
+    def get_mock_response_api_response_parse_error(self):
+        # Mock response for a malformed API response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'error': 'something happened'
+        }
+        return mock_response
+
+    def test_get_quality_gate_status_ok(self):
+        mock_response = self.get_mock_response_ok()
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            quality_gate_status, project_status = self.test_object.get_quality_gate_status()
+            code = self.test_object.extract_code_details(project_status, quality_gate_status)
+            
+            # Verify the API was called correctly
+            mock_get.assert_called_once()
+            self.assertEqual(quality_gate_status, 'OK')
+            self.assertEqual(code, '\n✅Status: OK, \nMetricKey: coverage\nComparator: GT\nErrorThreshold: 80\nActualValue: 85\n')
+
+    def test_get_quality_gate_status_error(self):
+        mock_response = self.get_mock_response_quality_gate_error()
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            quality_gate_status, project_status = self.test_object.get_quality_gate_status()
+            code = self.test_object.extract_code_details(project_status, quality_gate_status)
+            
+            # Verify the API was called correctly
+            mock_get.assert_called_once()
+            self.assertEqual(quality_gate_status, 'ERROR')
+            self.assertEqual(code, '\n💣Status: ERROR, \nMetricKey: coverage\nComparator: GT\nErrorThreshold: 80\nActualValue: 75\n')
+
+    def test_get_quality_gate_status_api_http_error(self):
+        mock_response = self.get_mock_response_api_http_error()
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            with self.assertRaises(RequestException):
+                self.test_object.get_quality_gate_status()
+            
+            # Verify the API was called correctly
+            mock_get.assert_called_once()
+
+    def test_get_quality_gate_status_api_response_parse_error(self):
+        mock_response = self.get_mock_response_api_response_parse_error()
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            with self.assertRaises(KeyError):
+                self.test_object.get_quality_gate_status()
+
+            # Verify the API was called correctly
+            mock_get.assert_called_once()
+
+    def test_code_validation_ok(self):
+        mock_response = self.get_mock_response_ok()
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            result = self.test_object.code_validation()
+
+            # Verify the API was called correctly
+            mock_get.assert_called_once()
+            self.assertTrue('Quality Gate has PASSED' in result)
+
+    def test_code_validation_error(self):
+        mock_response = self.get_mock_response_quality_gate_error()
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            result = self.test_object.code_validation()
+
+            # Verify the API was called correctly
+            mock_get.assert_called_once()
+            self.assertTrue('Quality Gate has FAILED' in result)
+
+    def test_code_validation_api_http_error(self):
+        mock_response = self.get_mock_response_api_http_error()
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            result = self.test_object.code_validation()
+
+            # Verify the API was called correctly
+            mock_get.assert_called_once()
+            self.assertIn('quality_check=API ERROR: HTTP 401', result)
+
+    def test_code_validation_api_response_parse_error(self):
+        mock_response = self.get_mock_response_api_response_parse_error()
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            result = self.test_object.code_validation()
+
+            # Verify the API was called correctly
+            mock_get.assert_called_once()
+            self.assertIn('quality_check=API ERROR: PARSE ERROR', result)
+
+if __name__ == '__main__':
+    unittest.main() 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,10 +3,12 @@ import responses
 from requests.exceptions import RequestException
 from main import SonarQubePrComment
 from parameterized import parameterized
+from unittest.mock import patch, MagicMock
 
 class TestSonarQubeIntegration(unittest.TestCase):
     def setUp(self):
         self.quality_gate_url = None
+        self.github_api_base_url = None
         self.sonar_projectkey = None
         self.pr_number = None
 
@@ -20,6 +22,7 @@ class TestSonarQubeIntegration(unittest.TestCase):
                           github_api_base_url='https://api.github.com',
                           verbose='true'):
         self.quality_gate_url = f'{sonar_host_url}/api/qualitygates/project_status'
+        self.github_api_base_url = github_api_base_url
         self.sonar_projectkey = sonar_projectkey
         self.pr_number = pr_number
         return SonarQubePrComment(
@@ -262,6 +265,49 @@ class TestSonarQubeIntegration(unittest.TestCase):
         # Assert
         self.assertTrue('Quality Gate has PASSED' in result)
         self.assertEqual(len(responses.calls), 1)
+
+    @patch('main.Github')
+    def test_comment_on_pull_request_ok(self, mock_github_class):
+        # Arrange
+        test_object = self.setup_test_object()
+
+        # Setup mock objects
+        mock_github = MagicMock()
+        mock_repo = MagicMock()
+        mock_pull = MagicMock()
+
+        # Configure the mock chain
+        mock_github_class.return_value = mock_github
+        mock_github.get_repo.return_value = mock_repo
+        mock_repo.get_pull.return_value = mock_pull
+
+        # Act
+        test_object.comment_on_pull_request("Test comment")
+
+        # Assert
+        mock_github_class.assert_called_once_with(test_object.github_token, base_url=self.github_api_base_url)
+        mock_github.get_repo.assert_called_once_with(test_object.repo_name)
+        mock_repo.get_pull.assert_called_once_with(int(test_object.pr_number))
+        mock_pull.create_issue_comment.assert_called_once_with("Test comment")
+
+    @parameterized.expand([
+        ("no_config", None, None, None),
+        ("no_pr_number", "fake token", "fake repo", None),
+        ("empty_pr_number", "fake token", "fake repo", ""),
+        ("invalid_pr_number", "fake token", "fake repo", "abc123"),
+        ("no_github_token", None, "fake repo", "123"),
+        ("no_repo_name", "fake token", None, "123"),
+    ])
+    @patch('main.Github')
+    def test_comment_on_pull_request_invalid_github_config(self, name, github_token, repo_name, pr_number, mock_github_class):
+        # Arrange
+        test_object = self.setup_test_object(github_token=github_token, repo_name=repo_name, pr_number=pr_number)
+
+        # Act
+        test_object.comment_on_pull_request("Test comment")
+
+        # Assert
+        mock_github_class.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main() 


### PR DESCRIPTION
The current implementation uses the latest report from the _default_ branch, which isn't really what you want to be reported in your Pull Request. With this change, it will query SonarQube for the report associated with the PR.

Also added an optional "verbose" flag to help troubleshooting the step, as well as some unit tests.

If a PR is not provided, will fall back to original behavior of just getting the default branch status from SonarQube, but will not attempt to comment on a PR. Will also exit gracefully with error message if GitHub configuration is missing.